### PR TITLE
using urlParser instead of split to fix creation of longer signed urls

### DIFF
--- a/signer_test.go
+++ b/signer_test.go
@@ -1,6 +1,7 @@
 package signer
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -13,6 +14,12 @@ var signTests = []struct {
 	{
 		name:     "signable query params",
 		url:      "https://example.com/test?id=1",
+		validUrl: true,
+		hasError: false,
+	},
+	{
+		name:     "signable query params",
+		url:      "https://example.com/password/reset/finish?email=my@email.com",
 		validUrl: true,
 		hasError: false,
 	},
@@ -42,6 +49,9 @@ func TestSignature_SignURL(t *testing.T) {
 	for _, e := range signTests {
 		signed, err := sign.SignURL(e.url)
 
+		if e.validUrl && !strings.Contains(signed, e.url) {
+			t.Errorf("%s: was not returned correctly", e.url)
+		}
 		if err == nil && e.hasError {
 			t.Errorf("%s: does not have error, and should", e.name)
 		}

--- a/signer_test.go
+++ b/signer_test.go
@@ -18,7 +18,7 @@ var signTests = []struct {
 		hasError: false,
 	},
 	{
-		name:     "signable query params",
+		name:     "signable long path query params",
 		url:      "https://example.com/password/reset/finish?email=my@email.com",
 		validUrl: true,
 		hasError: false,


### PR DESCRIPTION
Updated the library in order to be able to sign url where the path is longer.
Added a specific test where module was not working properly
Ie. using url:
`https://example.com/password/reset/finish?email=my@email.com`